### PR TITLE
Pin GH actions to SHA to avoid mutable refs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,25 @@
 name: "build"
-
 on: ["pull_request", "push"]
-
 jobs:
   build:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Repository"
-        uses: "actions/checkout@v3"
-      - name : "Validate Gradle Wrapper"
-        uses : "gradle/wrapper-validation-action@v1"
+        uses: actions/checkout@v3
+      - name: "Validate Gradle Wrapper"
+        uses: "gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6" # v1
       - name: "Setup Java"
-        uses: "actions/setup-java@v3"
+        uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: "17"
       - name: "Clean Build"
         run: "./gradlew clean build"
-      - name : "Archive Artifacts"
-        uses : "actions/upload-artifact@v3"
-        with :
-          name : "HTTP4J-SNAPSHOT"
-          path : "build/libs/*.jar"
+      - name: "Archive Artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: "HTTP4J-SNAPSHOT"
+          path: "build/libs/*.jar"
       - name: "Determine release status"
         if: "${{ runner.os == 'Linux' }}"
         run: |
@@ -33,14 +31,14 @@ jobs:
       - name: "Publish Release"
         if: "${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}"
         run: "./gradlew publishToSonatype closeSonatypeStagingRepository"
-        env :
-          ORG_GRADLE_PROJECT_sonatypeUsername : "${{ secrets.SONATYPE_USERNAME }}"
-          ORG_GRADLE_PROJECT_sonatypePassword : "${{ secrets.SONATYPE_PASSWORD }}"
-          ORG_GRADLE_PROJECT_signingKey : "${{ secrets.SIGNING_KEY }}"
-          ORG_GRADLE_PROJECT_signingPassword : "${{ secrets.SIGNING_PASSWORD }}"
-      - name : "Publish Snapshot"
-        if : "${{ runner.os == 'Linux' && env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
-        run : "./gradlew publishToSonatype"
-        env :
-          ORG_GRADLE_PROJECT_sonatypeUsername : "${{ secrets.SONATYPE_USERNAME }}"
-          ORG_GRADLE_PROJECT_sonatypePassword : "${{ secrets.SONATYPE_PASSWORD }}"
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: "${{ secrets.SONATYPE_USERNAME }}"
+          ORG_GRADLE_PROJECT_sonatypePassword: "${{ secrets.SONATYPE_PASSWORD }}"
+          ORG_GRADLE_PROJECT_signingKey: "${{ secrets.SIGNING_KEY }}"
+          ORG_GRADLE_PROJECT_signingPassword: "${{ secrets.SIGNING_PASSWORD }}"
+      - name: "Publish Snapshot"
+        if: "${{ runner.os == 'Linux' && env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
+        run: "./gradlew publishToSonatype"
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: "${{ secrets.SONATYPE_USERNAME }}"
+          ORG_GRADLE_PROJECT_sonatypePassword: "${{ secrets.SONATYPE_PASSWORD }}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,14 +1,12 @@
 name: draft release
-
 on:
   push:
     branches:
       - main
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
   pull_request_target:
-    types: [ opened, reopened, synchronize ]
-
+    types: [opened, reopened, synchronize]
 jobs:
   update_release_draft:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
GitHub actions are mutable if not pinned, which allow modifications without revision changes. Let's pin external versions to ensure the version specified matches the version GH action pulls.