### PR TITLE
Implement check for HTTP_CREATED

### DIFF
--- a/src/main/java/com/intellectualsites/http/HttpRequest.java
+++ b/src/main/java/com/intellectualsites/http/HttpRequest.java
@@ -122,7 +122,7 @@ final class HttpRequest {
 
             final InputStream stream;
             if (this.method.hasBody()) {
-                if (httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_OK && httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_CREATED) {
+                if (httpURLConnection.getResponseCode() >= 400) {
                     stream = httpURLConnection.getErrorStream();
                 } else {
                     stream = httpURLConnection.getInputStream();

--- a/src/main/java/com/intellectualsites/http/HttpRequest.java
+++ b/src/main/java/com/intellectualsites/http/HttpRequest.java
@@ -122,7 +122,7 @@ final class HttpRequest {
 
             final InputStream stream;
             if (this.method.hasBody()) {
-                if (httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                if (httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_OK || httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_CREATED) {
                     stream = httpURLConnection.getErrorStream();
                 } else {
                     stream = httpURLConnection.getInputStream();

--- a/src/main/java/com/intellectualsites/http/HttpRequest.java
+++ b/src/main/java/com/intellectualsites/http/HttpRequest.java
@@ -122,7 +122,7 @@ final class HttpRequest {
 
             final InputStream stream;
             if (this.method.hasBody()) {
-                if (httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_OK || httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_CREATED) {
+                if (httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_OK && httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_CREATED) {
                     stream = httpURLConnection.getErrorStream();
                 } else {
                     stream = httpURLConnection.getInputStream();


### PR DESCRIPTION
## Overview
When a 201 - Created response is returned, HTTP4J won't return the body of the content. While this isn't a "OK" response, it still can return a body.

Not sure what other response types exist.

Fixes #54
